### PR TITLE
feat(client): add commenting and missing set for solenoid actuation

### DIFF
--- a/src/button.rs
+++ b/src/button.rs
@@ -8,7 +8,7 @@ pub async fn bypass<Button: Pin, Valve: Pin>(
 ) -> Result<(), GpioError> {
     loop {
         button.wait_for_falling_edge().await?;
-        valve.lock().unwrap().set_high()?;
+        valve.lock().unwrap().set_high()?; // Manual bypass should allow water to flow.
         log::warn!("manual bypass requested by the reset button");
     }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -30,6 +30,7 @@ pub async fn report<Tap: Pin, Valve: Pin>(
         if tap.is_low() && flow > 10 {
             if report_leak(&mut http, &addr.0).await.map_err(|EspIOError(err)| err)? {
                 log::warn!("leak detected for the first time");
+                valve.lock().unwrap().set_low()?; // Stop water flow.
             } else {
                 log::error!("leak detected multiple times");
             }
@@ -40,7 +41,7 @@ pub async fn report<Tap: Pin, Valve: Pin>(
             continue;
         }
 
-        valve.lock().unwrap().set_low()?;
+        valve.lock().unwrap().set_high()?; // We received a 503, we need to resume water flow.
         log::warn!("remote shutdown requested by the Cloud");
     }
 }


### PR DESCRIPTION
This PR aims to add the missing logic of setting the solenoid to block water flow when the unit alarms for the first time.
This also reverses the logic of the solenoid pin when receiving a 503 from the server.