### PR TITLE
feat: manual bypass redux

### DIFF
--- a/src/button.rs
+++ b/src/button.rs
@@ -1,0 +1,24 @@
+use core::sync::atomic::{AtomicBool, Ordering};
+use esp_idf_hal::gpio::{Input, Pin, PinDriver};
+use esp_idf_svc::errors::EspIOError;
+use esp_idf_sys::EspError;
+use std::sync::{Arc, Mutex};
+
+use crate::http::{bypass, HttpClient};
+
+pub async fn deactivate_bypass_mode<Button: Pin>(
+    http: Arc<Mutex<HttpClient>>,
+    should_bypass: Arc<AtomicBool>,
+    mut button: PinDriver<'_, Button, Input>,
+) -> Result<(), EspError> {
+    loop {
+        button.wait_for_falling_edge().await.map_err(|err| err.cause())?;
+        if should_bypass.swap(false, Ordering::Relaxed) {
+            let mut guard = http.lock().unwrap();
+            bypass(&mut guard).await.map_err(|EspIOError(err)| err)?;
+            log::info!("undid bypass mode");
+        } else {
+            log::warn!("system is already in normal operation");
+        }
+    }
+}

--- a/src/button.rs
+++ b/src/button.rs
@@ -2,11 +2,13 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use esp_idf_hal::gpio::{Input, Pin, PinDriver};
 use esp_idf_svc::errors::EspIOError;
 use esp_idf_sys::EspError;
+use model::MacAddress;
 use std::sync::{Arc, Mutex};
 
 use crate::http::{bypass, HttpClient};
 
 pub async fn deactivate_bypass_mode<Button: Pin>(
+    mac: MacAddress,
     http: Arc<Mutex<HttpClient>>,
     should_bypass: Arc<AtomicBool>,
     mut button: PinDriver<'_, Button, Input>,
@@ -15,8 +17,8 @@ pub async fn deactivate_bypass_mode<Button: Pin>(
         button.wait_for_falling_edge().await.map_err(|err| err.cause())?;
         if should_bypass.swap(false, Ordering::Relaxed) {
             let mut guard = http.lock().unwrap();
-            bypass(&mut guard).await.map_err(|EspIOError(err)| err)?;
-            log::info!("undid bypass mode");
+            bypass(&mut guard, &mac.0).await.map_err(|EspIOError(err)| err)?;
+            log::warn!("undid bypass mode");
         } else {
             log::warn!("system is already in normal operation");
         }

--- a/src/http.rs
+++ b/src/http.rs
@@ -65,10 +65,10 @@ pub async fn ping(http: &mut HttpClient, ping: &Ping) -> Result<Command, EspIOEr
     })
 }
 
-pub async fn bypass(http: &mut HttpClient) -> Result<(), EspIOError> {
+pub async fn bypass(http: &mut HttpClient, mac: &[u8]) -> Result<(), EspIOError> {
     const ENDPOINT: &str = concat!(env!("BASE_URL"), "/report/bypass");
     let mut buf = [];
-    let Post { count, status } = send_post(http, ENDPOINT, &[], &mut buf).await?;
+    let Post { count, status } = send_post(http, ENDPOINT, mac, &mut buf).await?;
     assert_eq!(count, 0);
     assert_eq!(status, 201);
     Ok(())

--- a/src/http.rs
+++ b/src/http.rs
@@ -64,3 +64,12 @@ pub async fn ping(http: &mut HttpClient, ping: &Ping) -> Result<Command, EspIOEr
         _ => core::unreachable!(),
     })
 }
+
+pub async fn bypass(http: &mut HttpClient) -> Result<(), EspIOError> {
+    const ENDPOINT: &str = concat!(env!("BASE_URL"), "/report/bypass");
+    let mut buf = [];
+    let Post { count, status } = send_post(http, ENDPOINT, &[], &mut buf).await?;
+    assert_eq!(count, 0);
+    assert_eq!(status, 201);
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ fn main() -> Result<(), EspError> {
         let http = Arc::new(Mutex::new(http));
         exec.spawn_detached(flow::detect(flow))
             .unwrap()
-            .spawn_local_detached(button::deactivate_bypass_mode(http.clone(), bypass.clone(), bypass_button))
+            .spawn_local_detached(button::deactivate_bypass_mode(mac, http.clone(), bypass.clone(), bypass_button))
             .unwrap()
             .spawn_local_detached(snapshot::report(mac, timer, http, bypass, tap, tap_led, valve))
             .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
+mod button;
 mod flow;
 mod http;
 mod net;
 mod snapshot;
 mod valve;
 
+use core::sync::atomic::AtomicBool;
 use embedded_svc::{http::client::asynch::TrivialUnblockingConnection, utils::asyncify::Asyncify as _, wifi};
 use esp_idf_hal::{
     gpio::{PinDriver, Pins},
@@ -19,6 +21,7 @@ use esp_idf_svc::{
     wifi::{AsyncWifi, EspWifi},
 };
 use esp_idf_sys::{self as _, EspError};
+use std::sync::{Arc, Mutex};
 
 fn main() -> Result<(), EspError> {
     // It is necessary to call this function once. Otherwise some patches to the runtime
@@ -27,12 +30,13 @@ fn main() -> Result<(), EspError> {
 
     esp_idf_svc::log::EspLogger::initialize_default();
 
-    // NOTE: GPIO 22 used to be the manual bypass button in the hardware (for debugging).
     let Peripherals {
         modem,
         pins:
             Pins {
+                gpio2: ready_led_pin,
                 gpio21: tap_sensor_pin,
+                gpio22: bypass_button_pin,
                 gpio23: valve_pin,
                 gpio34: flow_sensor_pin,
                 gpio33: tap_led_pin,
@@ -43,15 +47,20 @@ fn main() -> Result<(), EspError> {
     } = Peripherals::take().ok_or_else(EspError::from_infallible::<-1>)?;
 
     // Set up pins
+    let mut ready_led = PinDriver::output(ready_led_pin)?;
     let valve = PinDriver::output(valve_pin)?;
     let tap = PinDriver::input(tap_sensor_pin)?;
+    let mut bypass_button = PinDriver::input(bypass_button_pin)?;
     let tap_led = PinDriver::output(tap_led_pin)?;
     let valve_led = PinDriver::output(valve_led_pin)?;
     let flow = PinDriver::input(flow_sensor_pin)?;
 
+    // Set the pull mode of the pins
+    bypass_button.set_pull(esp_idf_hal::gpio::Pull::Up)?;
+
     // Allow the water to flow
     let mut valve = valve::ValveSystem { control: valve, led: valve_led };
-    valve.start_flow()?;
+    valve.start_flow()?; // this will be re-initialized later on registration
 
     // Initialize other services
     let sysloop = EspSystemEventLoop::take()?;
@@ -74,11 +83,38 @@ fn main() -> Result<(), EspError> {
 
     let exec = EspExecutor::<4, _>::new();
     exec.spawn_local_detached(async {
+        // Initialize Wi-Fi
         let mac = net::init(&mut wifi).await?;
-        http::register_to_server(&mut http, &mac.0).await.map_err(|EspIOError(err)| err)?;
+
+        // Initialize the pipe state
+        let command = http::register_to_server(&mut http, &mac.0).await.map_err(|EspIOError(err)| err)?;
+        let init = match command {
+            http::Command::None => {
+                log::info!("no pending commands from the server");
+                false
+            }
+            http::Command::Close => {
+                log::info!("server initialized the system with a close command");
+                valve.stop_flow()?;
+                false
+            }
+            http::Command::Open => {
+                log::info!("server initialized the system with an open command");
+                valve.start_flow()?;
+                true
+            }
+        };
+        let bypass = Arc::new(AtomicBool::new(init));
+
+        // Turn on the LED to find out whether
+        ready_led.set_high()?;
+
+        let http = Arc::new(Mutex::new(http));
         exec.spawn_detached(flow::detect(flow))
             .unwrap()
-            .spawn_local_detached(snapshot::report(mac, timer, http, tap, tap_led, valve))
+            .spawn_local_detached(button::deactivate_bypass_mode(http.clone(), bypass.clone(), bypass_button))
+            .unwrap()
+            .spawn_local_detached(snapshot::report(mac, timer, http, bypass, tap, tap_led, valve))
             .unwrap();
         Ok::<_, EspError>(())
     })

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,9 +1,13 @@
-use core::time::Duration;
+use core::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
 use embedded_svc::utils::asyncify::timer::AsyncTimer;
 use esp_idf_hal::gpio::{Input, Output, Pin, PinDriver};
 use esp_idf_svc::{errors::EspIOError, timer::EspTimer};
 use esp_idf_sys::EspError;
 use model::{report::Ping, MacAddress};
+use std::sync::{Arc, Mutex};
 
 use crate::{
     flow::take_ticks,
@@ -14,7 +18,8 @@ use crate::{
 pub async fn report<Tap: Pin, Valve: Pin, TapLed: Pin, ValveLed: Pin>(
     addr: MacAddress,
     mut timer: AsyncTimer<EspTimer>,
-    mut http: HttpClient,
+    http: Arc<Mutex<HttpClient>>,
+    should_bypass: Arc<AtomicBool>,
     tap: PinDriver<'_, Tap, Input>,
     mut tap_led: PinDriver<'_, TapLed, Output>,
     mut valve: ValveSystem<'_, Valve, ValveLed>,
@@ -43,9 +48,14 @@ pub async fn report<Tap: Pin, Valve: Pin, TapLed: Pin, ValveLed: Pin>(
         };
 
         // NOTE: We send the normalized number of ticks (i.e., ticks per second) to the Cloud.
-        match ping(&mut http, &Ping { addr, leak, flow: unit }).await.map_err(|EspIOError(err)| err)? {
+        let mut guard = http.lock().unwrap();
+        let command = ping(&mut guard, &Ping { addr, leak, flow: unit }).await.map_err(|EspIOError(err)| err)?;
+        drop(guard);
+
+        match command {
             Command::None => log::info!("no command issued from the server"),
             Command::Open => {
+                should_bypass.store(true, Ordering::Relaxed);
                 valve.start_flow()?;
                 log::warn!("server issued a remote bypass");
             }


### PR DESCRIPTION
This PR implements the manual bypass in the hardware. We reintroduce the manual bypass button, but it is no longer a toggle switch. It may deactivate the bypass mode. Only the PWA has the sole right to activate the bypass mode, which vastly simplifies the logic.